### PR TITLE
Redirect `/` to `/current/`

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,4 @@
-define: prefix docs/drivers/kotlin
+define: prefix docs/drivers/kotlin/coroutine
 define: base https://www.mongodb.com/${prefix}
-define: versions master
 
 raw: ${prefix}/ -> ${base}/current/
-


### PR DESCRIPTION
# Pull Request Info

Redirect https://www.mongodb.com/docs/drivers/kotlin/coroutine/ to https://www.mongodb.com/docs/drivers/kotlin/coroutine/current/

based on how java docs does it - https://github.com/mongodb/docs-java/blob/master/config/redirects

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - n/a
Staging - n/a

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
