### PR TITLE
(DOCSP-29415): Update GH action to run local mongoDB server

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mongodb-version: ['4.2', '4.4', '5.0', '6.0']
+        mongodb-version: ['6.0']
 
     steps:
       - uses: actions/checkout@v3
@@ -29,27 +29,13 @@ jobs:
         uses: supercharge/mongodb-github-action@1.9.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
-          # mongodb-username: supercharge
-          # mongodb-password: secret
-          # mongodb-db: supercharge
+          mongodb-replica-set: test-rs
   
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
   
-      - name: Set up Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-  
-      - run: ./gradlew build
-  
-      - run: ./gradlew test --stacktrace --info
+      - name: Run Tests
+        run: ./gradlew test --stacktrace --info
         env: 
           CI: true
-          # CONNECTION_STRING: mongodb://supercharge:secret@localhost:27017/supercharge?authSource=admin
-          CONNECTION_STRING: mongodb://localhost:27017
+          CONNECTION_URI: "mongodb://localhost:27017"

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -12,7 +12,10 @@ defaults:
 jobs:
   build:
     name: Run Kotlin Example Tests
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mongodb-version: ['4.2', '4.4', '5.0', '6.0']
 
     steps:
       - uses: actions/checkout@v3
@@ -21,8 +24,32 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Run Kotlin tests
-        run: ./gradlew test --stacktrace --info
+    
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.9.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+          # mongodb-username: supercharge
+          # mongodb-password: secret
+          # mongodb-db: supercharge
+  
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+  
+      - name: Set up Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+  
+      - run: ./gradlew build
+  
+      - run: ./gradlew test --stacktrace --info
         env: 
           CI: true
-          CONNECTION_URI: ${{ secrets.CONNECTION_URI }}
+          # CONNECTION_STRING: mongodb://supercharge:secret@localhost:27017/supercharge?authSource=admin
+          CONNECTION_STRING: mongodb://localhost:27017

--- a/examples/src/test/kotlin/BuildersTest.kt
+++ b/examples/src/test/kotlin/BuildersTest.kt
@@ -56,7 +56,6 @@ internal class BuildersTest {
                 client.close()
             }
         }
-
     }
 
     @Test

--- a/examples/src/test/kotlin/ChangeTest.kt
+++ b/examples/src/test/kotlin/ChangeTest.kt
@@ -53,6 +53,7 @@ internal class ChangeTest {
             }
         }
     }
+
     @Test
     fun updateOneTest() = runBlocking {
         // :snippet-start: update-one

--- a/examples/src/test/kotlin/ConnectTest.kt
+++ b/examples/src/test/kotlin/ConnectTest.kt
@@ -63,7 +63,7 @@ internal class ConnectionTest {
         }
         // :snippet-end:
         higherScopedClient = mongoClient
-        assertEquals(1.0, higherScopedCommandResult["ok"])
+        assertEquals(1.0, higherScopedCommandResult["ok"].toString().toDouble())
     }
 
     @Test

--- a/examples/src/test/kotlin/ConnectTest.kt
+++ b/examples/src/test/kotlin/ConnectTest.kt
@@ -63,7 +63,7 @@ internal class ConnectionTest {
         }
         // :snippet-end:
         higherScopedClient = mongoClient
-        assertEquals(1, higherScopedCommandResult["ok"])
+        assertEquals(1.0, higherScopedCommandResult["ok"])
     }
 
     @Test

--- a/examples/src/test/kotlin/LimitTest.kt
+++ b/examples/src/test/kotlin/LimitTest.kt
@@ -11,17 +11,17 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import kotlin.test.*
 
-// :snippet-start: data-model
-data class Book(
-    @BsonId val id: Int,
-    val title: String,
-    val author: String,
-    val length: Int
-)
-// :snippet-end:
-
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class LimitTest {
+
+    // :snippet-start: data-model
+    data class Book(
+        @BsonId val id: Int,
+        val title: String,
+        val author: String,
+        val length: Int
+    )
+    // :snippet-end:
 
     companion object {
         val config = getConfig()

--- a/examples/src/test/kotlin/LoggingTest.kt
+++ b/examples/src/test/kotlin/LoggingTest.kt
@@ -1,7 +1,3 @@
-
-
-// :snippet-start: slf4j-import
-// :snippet-end:
 import InsertTest.Companion.client
 import com.mongodb.kotlin.client.coroutine.MongoClient
 import config.getConfig
@@ -11,7 +7,9 @@ import org.bson.Document
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.TestInstance
+// :snippet-start: slf4j-import
 import org.slf4j.LoggerFactory
+// :snippet-end:
 import java.util.*
 import kotlin.test.*
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

Updates the GH action to run a local server. Any pending PRs will need to be updated to use `getConfig()` or the test will fail.
> NOTE: Currently, it creates a replica set with no users.

JIRA - https://jira.mongodb.org/browse/DOCSP-29415
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kotlin/docsworker-xlarge/no-jira-logging-import-fix/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
