### PR TITLE
Gradle snippet update

### DIFF
--- a/source/includes/kotlin-driver-coroutine-gradle-versioned.rst
+++ b/source/includes/kotlin-driver-coroutine-gradle-versioned.rst
@@ -4,5 +4,4 @@
 
    dependencies {
        implementation("org.mongodb:mongodb-driver-kotlin-coroutine:{+full-version+}")
-       implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:+")
    }


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

Per Slack convo, the coroutine library is a runtime dependency and can be removed from the Gradle snippet

JIRA - no jira
Staging - https://docs-mongodborg-staging.corp.mongodb.com/kotlin/docsworker-xlarge/dependency-update/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
