### PR TITLE
DOCSP-30063: specify return type using withDocument

### DIFF
--- a/examples/src/test/kotlin/DataClassTest.kt
+++ b/examples/src/test/kotlin/DataClassTest.kt
@@ -78,14 +78,21 @@ internal class DataClassTest {
 
         // :snippet-start: retrieve-diff-data-class
         // Define a data class for returned documents
-        data class NewDataStorage(val productName: String, val capacity: Double, val releaseDate: LocalDate)
+        data class NewDataStorage(
+            val productName: String,
+            val capacity: Double,
+            val releaseDate: LocalDate
+        )
 
         val filter = Filters.eq(DataStorage::productName.name, "tape")
         val update = Updates.currentDate("releaseDate")
         val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
 
         // Specify the class for returned documents as the type parameter in withDocumentClass()
-        val result = collection.withDocumentClass<NewDataStorage>().findOneAndUpdate(filter, update, options)
+        val result = collection
+            .withDocumentClass<NewDataStorage>()
+            .findOneAndUpdate(filter, update, options)
+
         println("Updated document: ${result}")
         // :snippet-end:
     }

--- a/examples/src/test/kotlin/DataClassTest.kt
+++ b/examples/src/test/kotlin/DataClassTest.kt
@@ -1,5 +1,8 @@
 
 import com.mongodb.client.model.Filters
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
+import com.mongodb.client.model.Updates
 import com.mongodb.kotlin.client.coroutine.MongoClient
 import config.getConfig
 import kotlinx.coroutines.flow.count
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.TestInstance
+import java.time.LocalDate
 import java.util.*
 import kotlin.test.*
 
@@ -71,6 +75,19 @@ internal class DataClassTest {
         resultsFlow.collect { println(it) }
         // :snippet-end:
         assertEquals(tape, resultsFlow.firstOrNull())
+
+        // :snippet-start: retrieve-diff-data-class
+        // Define a data class for returned documents
+        data class NewDataStorage(val productName: String, val capacity: Double, val releaseDate: LocalDate)
+
+        val filter = Filters.eq(DataStorage::productName.name, "tape")
+        val update = Updates.currentDate("releaseDate")
+        val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+
+        // Specify the class for returned documents as the type parameter in withDocumentClass()
+        val result = collection.withDocumentClass<NewDataStorage>().findOneAndUpdate(filter, update, options)
+        println("Updated document: ${result}")
+        // :snippet-end:
     }
 
     // :snippet-start: annotated-data-class

--- a/examples/src/test/kotlin/DatabaseCollectionsTest.kt
+++ b/examples/src/test/kotlin/DatabaseCollectionsTest.kt
@@ -1,7 +1,5 @@
 
-import com.mongodb.client.model.CreateCollectionOptions
-import com.mongodb.client.model.Filters
-import com.mongodb.client.model.ValidationOptions
+import com.mongodb.client.model.*
 import com.mongodb.kotlin.client.coroutine.MongoClient
 import config.getConfig
 import kotlinx.coroutines.flow.toList
@@ -9,10 +7,12 @@ import kotlinx.coroutines.runBlocking
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.TimeUnit
+import kotlin.test.Ignore
 import kotlin.test.assertTrue
-
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class DatabaseCollectionsTest {
@@ -85,5 +85,45 @@ internal class DatabaseCollectionsTest {
         // Junit test for the above code
         val collectionList = database.listCollectionNames().toList()
         assertTrue(collectionList.contains("movies"))
+    }
+
+    // :snippet-start: fruit-data-class
+    data class Fruit(
+        @BsonId val id: Int,
+        val name: String,
+        val qty: Int,
+        val seasons: List<String>
+    )
+    // :snippet-end:
+
+    @Test
+    fun returnTypeTest() = runBlocking {
+        database.createCollection("fruits")
+        // :snippet-start: return-type
+        val collection =
+            database.getCollection<Fruit>("fruits")
+        collection.insertOne(Fruit(1, "strawberry", 205, listOf("summer"))) // :remove:
+
+        data class NewFruit(
+            @BsonId val id: Int,
+            val name: String,
+            val quantity: Int,
+            val seasons: List<String>
+        )
+
+        val filter = Filters.eq(Fruit::name.name, "strawberry")
+        val update = Updates.combine(
+            Updates.rename(Fruit::qty.name, "quantity"),
+            Updates.push(Fruit::seasons.name, "fall"),
+        )
+        val options = FindOneAndUpdateOptions()
+            .returnDocument(ReturnDocument.AFTER)
+
+        val result = collection.withDocumentClass<NewFruit>().findOneAndUpdate(filter, update, options)
+        print(result)
+        // :snippet-end:
+
+        // Junit test for the above code
+        Assertions.assertEquals(NewFruit(1,"strawberry", 205, listOf("summer", "fall")), result)
     }
 }

--- a/examples/src/test/kotlin/DatabaseCollectionsTest.kt
+++ b/examples/src/test/kotlin/DatabaseCollectionsTest.kt
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.util.concurrent.TimeUnit
-import kotlin.test.Ignore
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/examples/src/test/kotlin/DatabaseCollectionsTest.kt
+++ b/examples/src/test/kotlin/DatabaseCollectionsTest.kt
@@ -104,6 +104,7 @@ internal class DatabaseCollectionsTest {
             database.getCollection<Fruit>("fruits")
         collection.insertOne(Fruit(1, "strawberry", 205, listOf("summer"))) // :remove:
 
+        // Define a data class for returned documents
         data class NewFruit(
             @BsonId val id: Int,
             val name: String,
@@ -119,8 +120,11 @@ internal class DatabaseCollectionsTest {
         val options = FindOneAndUpdateOptions()
             .returnDocument(ReturnDocument.AFTER)
 
-        val result = collection.withDocumentClass<NewFruit>().findOneAndUpdate(filter, update, options)
-        print(result)
+        // Specify the class for returned documents as the type parameter in withDocumentClass()
+        val result = collection
+            .withDocumentClass<NewFruit>()
+            .findOneAndUpdate(filter, update, options)
+        println(result)
         // :snippet-end:
 
         // Junit test for the above code

--- a/source/examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
+++ b/source/examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
@@ -1,0 +1,10 @@
+// Define a data class for returned documents
+data class NewDataStorage(val productName: String, val capacity: Double, val releaseDate: LocalDate)
+
+val filter = Filters.eq(DataStorage::productName.name, "tape")
+val update = Updates.currentDate("releaseDate")
+val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+
+// Specify the class for returned documents as the type parameter in withDocumentClass()
+val result = collection.withDocumentClass<NewDataStorage>().findOneAndUpdate(filter, update, options)
+println("Updated document: ${result}")

--- a/source/examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
+++ b/source/examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
@@ -1,10 +1,17 @@
 // Define a data class for returned documents
-data class NewDataStorage(val productName: String, val capacity: Double, val releaseDate: LocalDate)
+data class NewDataStorage(
+    val productName: String,
+    val capacity: Double,
+    val releaseDate: LocalDate
+)
 
 val filter = Filters.eq(DataStorage::productName.name, "tape")
 val update = Updates.currentDate("releaseDate")
 val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
 
 // Specify the class for returned documents as the type parameter in withDocumentClass()
-val result = collection.withDocumentClass<NewDataStorage>().findOneAndUpdate(filter, update, options)
+val result = collection
+    .withDocumentClass<NewDataStorage>()
+    .findOneAndUpdate(filter, update, options)
+
 println("Updated document: ${result}")

--- a/source/examples/generated/DatabaseCollectionsTest.snippet.fruit-data-class.kt
+++ b/source/examples/generated/DatabaseCollectionsTest.snippet.fruit-data-class.kt
@@ -1,0 +1,6 @@
+data class Fruit(
+    @BsonId val id: Int,
+    val name: String,
+    val qty: Int,
+    val seasons: List<String>
+)

--- a/source/examples/generated/DatabaseCollectionsTest.snippet.return-type.kt
+++ b/source/examples/generated/DatabaseCollectionsTest.snippet.return-type.kt
@@ -1,6 +1,7 @@
 val collection =
     database.getCollection<Fruit>("fruits")
 
+// Define a data class for returned documents
 data class NewFruit(
     @BsonId val id: Int,
     val name: String,
@@ -16,5 +17,8 @@ val update = Updates.combine(
 val options = FindOneAndUpdateOptions()
     .returnDocument(ReturnDocument.AFTER)
 
-val result = collection.withDocumentClass<NewFruit>().findOneAndUpdate(filter, update, options)
-print(result)
+// Specify the class for returned documents as the type parameter in withDocumentClass()
+val result = collection
+    .withDocumentClass<NewFruit>()
+    .findOneAndUpdate(filter, update, options)
+println(result)

--- a/source/examples/generated/DatabaseCollectionsTest.snippet.return-type.kt
+++ b/source/examples/generated/DatabaseCollectionsTest.snippet.return-type.kt
@@ -1,0 +1,20 @@
+val collection =
+    database.getCollection<Fruit>("fruits")
+
+data class NewFruit(
+    @BsonId val id: Int,
+    val name: String,
+    val quantity: Int,
+    val seasons: List<String>
+)
+
+val filter = Filters.eq(Fruit::name.name, "strawberry")
+val update = Updates.combine(
+    Updates.rename(Fruit::qty.name, "quantity"),
+    Updates.push(Fruit::seasons.name, "fall"),
+)
+val options = FindOneAndUpdateOptions()
+    .returnDocument(ReturnDocument.AFTER)
+
+val result = collection.withDocumentClass<NewFruit>().findOneAndUpdate(filter, update, options)
+print(result)

--- a/source/fundamentals/data-formats/document-data-format-data-class.txt
+++ b/source/fundamentals/data-formats/document-data-format-data-class.txt
@@ -62,6 +62,29 @@ as shown in the following code:
 
       DataStorage(productName=tape, capacity=5.0)
 
+You specify a class for documents returned from a collection, even if it
+is different than the class you specified when retrieving the
+collection.
+
+The following example performs an update to the document
+represented by the ``DataStorage`` data class in the previous example
+and returns the updated document as a ``NewDataStorage`` type:
+
+.. io-code-block::
+   :copyable: true
+
+   .. input:: /examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
+      :language: kotlin
+      :emphasize-lines: 2,9
+
+   .. output::
+      :language: console
+
+      Updated document: NewDataStorage(productName=tape, capacity=5.0, releaseDate=2023-06-15)
+
+For more information about this feature, see :ref:`Specify Return Type
+<db-coll-specify-return-type>` in the Databases and Collections guide.
+
 .. _fundamentals-data-class-annotations:
 
 Specify Component Conversion Using Annotations

--- a/source/fundamentals/data-formats/document-data-format-data-class.txt
+++ b/source/fundamentals/data-formats/document-data-format-data-class.txt
@@ -4,8 +4,6 @@
 Document Data Format: Data Classes
 ==================================
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -68,14 +66,16 @@ collection.
 
 The following example performs an update to the document
 represented by the ``DataStorage`` data class in the previous example
-and returns the updated document as a ``NewDataStorage`` type:
+and returns the updated document as a ``NewDataStorage`` type. The
+operation adds the ``releaseDate`` field to the document with a
+``name`` value of ``tape``:
 
 .. io-code-block::
    :copyable: true
 
    .. input:: /examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
       :language: kotlin
-      :emphasize-lines: 2-6,14
+      :emphasize-lines: 2-6,13-15
 
    .. output::
       :language: console

--- a/source/fundamentals/data-formats/document-data-format-data-class.txt
+++ b/source/fundamentals/data-formats/document-data-format-data-class.txt
@@ -75,7 +75,7 @@ and returns the updated document as a ``NewDataStorage`` type:
 
    .. input:: /examples/generated/DataClassTest.snippet.retrieve-diff-data-class.kt
       :language: kotlin
-      :emphasize-lines: 2,9
+      :emphasize-lines: 2-6,14
 
    .. output::
       :language: console

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -69,42 +69,6 @@ The following example accesses a collection named ``testCollection`` from a
    MongoDB implicitly creates the collection when you first insert data
    into that collection.
 
-Create a Collection
--------------------
-
-Use the `createCollection()
-<{+api-kotlin+}/apidocs/mongodb-driver-kotlin-coroutine/mongodb-driver-kotlin-coroutine/com.mongodb.kotlin.client.coroutine/-mongo-database/create-collection.html>`__
-method of a ``MongoDatabase`` instance to create a collection
-in a database of your connected MongoDB instance.
-
-The following example creates a collection called ``exampleCollection``:
-
-.. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.create-collection.kt
-   :language: kotlin
-
-You can specify collection options like maximum size and document
-validation rules using the `CreateCollectionOptions
-<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/CreateCollectionOptions.html>`__
-class. The ``createCollection()`` method accepts an instance of
-``CreateCollectionOptions`` as an optional second parameter.
-
-Document Validation
-~~~~~~~~~~~~~~~~~~~
-
-**Document validation** provides the ability to validate documents
-against a series of filters during writes to a collection. You can
-specify these filters using the `ValidationOptions
-<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/ValidationOptions.html>`__
-class, which accepts a series of `Filters
-<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html>`__ instances
-that specify the validation rules and expressions:
-
-.. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.validation.kt
-   :language: kotlin
-
-For more information, see the server documentation for :manual:`document
-validation </core/document-validation>`.
-
 .. _db-coll-specify-return-type:
 
 Specify Return Type
@@ -146,6 +110,42 @@ document with a ``name`` value of ``"strawberry"``:
       :language:  console
 
       NewFruit(id=1, name=strawberry, quantity=205, seasons=[summer, fall])
+
+Create a Collection
+-------------------
+
+Use the `createCollection()
+<{+api-kotlin+}/apidocs/mongodb-driver-kotlin-coroutine/mongodb-driver-kotlin-coroutine/com.mongodb.kotlin.client.coroutine/-mongo-database/create-collection.html>`__
+method of a ``MongoDatabase`` instance to create a collection
+in a database of your connected MongoDB instance.
+
+The following example creates a collection called ``exampleCollection``:
+
+.. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.create-collection.kt
+   :language: kotlin
+
+You can specify collection options like maximum size and document
+validation rules using the `CreateCollectionOptions
+<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/CreateCollectionOptions.html>`__
+class. The ``createCollection()`` method accepts an instance of
+``CreateCollectionOptions`` as an optional second parameter.
+
+Document Validation
+~~~~~~~~~~~~~~~~~~~
+
+**Document validation** provides the ability to validate documents
+against a series of filters during writes to a collection. You can
+specify these filters using the `ValidationOptions
+<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/ValidationOptions.html>`__
+class, which accepts a series of `Filters
+<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html>`__ instances
+that specify the validation rules and expressions:
+
+.. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.validation.kt
+   :language: kotlin
+
+For more information, see the server documentation for :manual:`document
+validation </core/document-validation>`.
       
 Get a List of Collections
 -------------------------

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -2,8 +2,6 @@
 Databases and Collections
 =========================
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -24,7 +22,7 @@ MongoDB organizes data into a hierarchy of the following levels:
 
 #. **Documents**: Documents contain literal data such as strings, numbers, and dates, as well as other embedded documents. For more information on document field types and structure, see the :manual:`Server documentation on documents </core/document/>`.
 
-With the MongoDB Kotlin driver, You can model data by using Kotlin data
+With the MongoDB Kotlin driver, you can model data by using Kotlin data
 classes or by using the `Document
 <{+api+}/apidocs/bson/org/bson/Document.html>`__ class to store and
 retrieve data from MongoDB.
@@ -127,10 +125,12 @@ situations:
 - You cannot directly specify a return type on a method that changes the data,
   such as ``findOneAndUpdate()`` or ``findOneAndReplace()``.
 
-The following example shows how you can retrieve a collection that
-contains represented by the ``Fruit`` data class but return the result
+The following example retrieves a collection that
+contains data represented by the ``Fruit`` data class but returns the result
 of a ``findOneAndUpdate()`` operation as an instance of the ``NewFruit``
-class:
+class. The operation changes the name of the ``qty`` field to
+``quantity`` and adds an item to the ``seasons`` array field in the
+document with a ``name`` value of ``"strawberry"``:
 
 .. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.fruit-data-class.kt
    :language: kotlin

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -14,7 +14,7 @@ Overview
 --------
 
 In this guide, you can learn how to use MongoDB databases and
-collections with the MongoDB Kotlin driver. 
+collections with the MongoDB Kotlin driver.
 
 MongoDB organizes data into a hierarchy of the following levels:
 
@@ -22,15 +22,17 @@ MongoDB organizes data into a hierarchy of the following levels:
 
 #. **Collections**: Databases are organized into collections which contain **documents**.
 
-#. **Documents**: Documents contain literal data such as strings, numbers, and dates, as well as other embedded documents. For more information on document field types and structure, see the :manual:`server documentation for documents </core/document/>`. 
+#. **Documents**: Documents contain literal data such as strings, numbers, and dates, as well as other embedded documents. For more information on document field types and structure, see the :manual:`Server documentation on documents </core/document/>`.
 
-With the MongoDB Kotlin driver, data can be modeled using Kotlin data classes or you can use a 
-`Document <{+api+}/apidocs/bson/org/bson/Document.html>`__ class
-to store and retrieve data from MongoDB.
+With the MongoDB Kotlin driver, You can model data by using Kotlin data
+classes or by using the `Document
+<{+api+}/apidocs/bson/org/bson/Document.html>`__ class to store and
+retrieve data from MongoDB.
 
-.. TODO:(DOCSP-29224): add back in when document data format data classes are documented
-.. To learn more about using data classes to store and retrieve data, refer to
-.. :ref:`Document Data Format: Data Classes <fundamentals-data-classes>`.
+To learn more about using data classes, see
+the guide on the :ref:`Data Class Data Format
+<fundamentals-data-classes>`. To learn more about using the ``Document``
+class, see the guide on the :ref:`Document Data Format <kotlin-document-format>`.
 
 Access a Database
 -----------------
@@ -40,7 +42,7 @@ Use the `getDatabase()
 a ``MongoClient`` instance to access a ``MongoDatabase`` in a MongoDB
 instance.
 
-The following example accesses a database named "testDatabase":
+The following example accesses a database named ``testDatabase``:
 
 .. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.access-database.kt
    :language: kotlin
@@ -53,7 +55,7 @@ Use the `getCollection()
 method of a ``MongoDatabase`` instance to access a
 ``MongoCollection`` in a database of your connected MongoDB instance.
 
-The following example accesses a collection named "testCollection" from a 
+The following example accesses a collection named ``testCollection`` from a 
 ``MongoDatabase`` that contains documents of type ``ExampleDataClass``:
 
 .. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.test-data-class.kt
@@ -77,7 +79,7 @@ Use the `createCollection()
 method of a ``MongoDatabase`` instance to create a collection
 in a database of your connected MongoDB instance.
 
-The following example creates a collection called "exampleCollection":
+The following example creates a collection called ``exampleCollection``:
 
 .. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.create-collection.kt
    :language: kotlin
@@ -96,8 +98,8 @@ against a series of filters during writes to a collection. You can
 specify these filters using the `ValidationOptions
 <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/ValidationOptions.html>`__
 class, which accepts a series of `Filters
-<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html>`__
-that specifies the validation rules and expressions:
+<{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html>`__ instances
+that specify the validation rules and expressions:
 
 .. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.validation.kt
    :language: kotlin
@@ -105,6 +107,44 @@ that specifies the validation rules and expressions:
 For more information, see the server documentation for :manual:`document
 validation </core/document-validation>`.
 
+Specify Return Type
+~~~~~~~~~~~~~~~~~~~
+
+The driver provides a way for you to specify a class for documents
+returned from a collection, even if it is different than the class you
+specified when retrieving the collection. You can specify a return class
+by using the `MongoCollection.withDocumentClass()
+<{+api-kotlin+}/apidocs/mongodb-driver-kotlin-coroutine/mongodb-driver-kotlin-coroutine/com.mongodb.kotlin.client.coroutine/-mongo-collection/with-document-class.html>`__
+method.
+
+Specifying a different return class could be useful in the following
+situations:
+
+- Your collection contains multiple data types.
+- You specify a projection that changes your data fields.
+- You cannot directly specify a return type on a method that changes the data,
+  such as ``findOneAndUpdate()`` or ``findOneAndReplace()``.
+
+The following example shows how you can retrieve a collection that
+contains represented by the ``Fruit`` data class but return the result
+of a ``findOneAndUpdate()`` operation as an instance of the ``NewFruit``
+class:
+
+.. literalinclude:: /examples/generated/DatabaseCollectionsTest.snippet.fruit-data-class.kt
+   :language: kotlin
+   :caption: Fruit data model
+
+.. io-code-block::
+
+   .. input:: /examples/generated/DatabaseCollectionsTest.snippet.return-type.kt
+      :language:  kotlin
+      :emphasize-lines: 4-9, 19
+
+   .. output:: 
+      :language:  console
+
+      NewFruit(id=1, name=strawberry, quantity=205, seasons=[summer, fall])
+      
 Get a List of Collections
 -------------------------
 
@@ -179,7 +219,9 @@ normally inherit:
    the method is called retains its original preference and concern
    settings.
 
-For more information, see the server documentation on
-:manual:`read preferences </core/read-preference/>`,
-:manual:`read concerns </reference/read-concern/>`, and
-:manual:`write concerns </reference/write-concern/>`.
+For more information on these topics, see the following pages in the
+Server manual:
+
+- :manual:`Read Preference </core/read-preference/>`
+- :manual:`Read Concern </reference/read-concern/>`
+- :manual:`Write Concern </reference/write-concern/>`

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -107,6 +107,8 @@ that specify the validation rules and expressions:
 For more information, see the server documentation for :manual:`document
 validation </core/document-validation>`.
 
+.. _db-coll-specify-return-type:
+
 Specify Return Type
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -140,7 +140,7 @@ class:
 
    .. input:: /examples/generated/DatabaseCollectionsTest.snippet.return-type.kt
       :language:  kotlin
-      :emphasize-lines: 4-9, 19
+      :emphasize-lines: 5-10,21-23
 
    .. output:: 
       :language:  console


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-30063
Staging:
- [Specify return type in DB/coll page](https://docs-mongodbcom-staging.corp.mongodb.com/kotlin/docsworker-xlarge/DOCSP-30063-withDocument-method/fundamentals/databases-collections/#specify-return-type)
- [new content in data class doc format pg](https://docs-mongodbcom-staging.corp.mongodb.com/kotlin/docsworker-xlarge/DOCSP-30063-withDocument-method/fundamentals/data-formats/document-data-format-data-class/#retrieve-a-data-class)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
