### PR TITLE
(DOCSP-30215): Remove alpha label

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "kotlin"
-title = "Kotlin Coroutine (Alpha)"
+title = "Kotlin Coroutine"
 intersphinx = [
     "https://www.mongodb.com/docs/manual/objects.inv",
     "https://www.mongodb.com/docs/drivers/objects.inv",

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,6 +1,6 @@
-=============================
-MongoDB Kotlin Driver (Alpha)
-=============================
+=====================
+MongoDB Kotlin Driver
+=====================
 
 .. default-domain:: mongodb
 
@@ -18,13 +18,6 @@ MongoDB Kotlin Driver (Alpha)
    /issues-and-help
    /compatibility
    View the Source <https://github.com/mongodb/mongo-java-driver>
-
-.. note:: Alpha Release
-
-   The Kotlin driver is currently in alpha release and available only for evaluation purposes,
-   to validate functionality, and to gather feedback.
-   It is not recommended for production deployments as we may introduce breaking changes.
-   This feature doesn't include formal consulting, SLAs, or technical support obligations.
 
 Introduction
 ------------


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

Remove "Alpha" label and note
To be merged and deployed once Java v4.10 is released

JIRA - https://jira.mongodb.org/browse/DOCSP-30215
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kotlin/docsworker-xlarge/docsp-30215-alpha-label/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
