### PR TITLE
Update DevHub link on landing page

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -125,7 +125,7 @@ developers.
 
 To learn how to use MongoDB features with the Kotlin driver, see the
 :website:`Kotlin Tutorials and Articles </developer/languages/kotlin/>` page, which 
-includes our :website:`Getting Started with the {+driver-long+} </developer/products/mongodb/getting-started-kotlin-driver/>` 
+features our :website:`Getting Started with the {+driver-long+} </developer/products/mongodb/getting-started-kotlin-driver/>` 
 developer tutorial.
 
 To ask questions and engage in discussions with fellow developers using

--- a/source/index.txt
+++ b/source/index.txt
@@ -123,8 +123,10 @@ Developer Hub
 The Developer Hub provides tutorials and social engagement for
 developers.
 
-To learn how to use MongoDB features with the Kotlin driver, see the `How
-To's and Articles page <https://www.mongodb.com/developer/learn/?content=Articles&text=kotlin#main>`__.
+To learn how to use MongoDB features with the Kotlin driver, see the
+:website:`Kotlin Tutorials and Articles </developer/languages/kotlin/>` page, which 
+includes our :website:`Getting Started with the {+driver-long+} </developer/products/mongodb/getting-started-kotlin-driver/>` 
+developer tutorial.
 
 To ask questions and engage in discussions with fellow developers using
 the Kotlin Driver, visit the `MongoDB Developer Community <https://www.mongodb.com/community/forums/tag/kotlin>`__.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

- Update DevHub link on landing page to filter by language instead of a "Kotlin" keyword search (which links out to unsorted search results instead of newest content).
- Per Mohit's request, add Getting Started tutorial link to landing page Learn section

JIRA - no Jira
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/kotlin/docsworker-xlarge/no-jira-update-devhub-link/#developer-hub

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
