### PR TITLE
092123 trivial change to test GH action that copies compat tables

### DIFF
--- a/source/includes/language-compatibility-table-kotlin.rst
+++ b/source/includes/language-compatibility-table-kotlin.rst
@@ -7,6 +7,5 @@
    * - Kotlin Driver Version
      - Kotlin 1.8
 
-
    * - 4.10
      - ✓


### PR DESCRIPTION
# Pull Request Info

Note: no changes that affect format or content were made.

This PR contains a linebreak erasure to test that the API auth token that the "Copy to docs shared" GH action depends on functions correctly. The PR contain a change to the compatibility table files and be merged to trigger the GH action.


[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA: none
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/kotlin/092123-test-shared-copy-action/compatibility/#language-compatibility

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
