### PR TITLE
092223 compatibility copy

### DIFF
--- a/.github/workflows/copy-compat-to-docs-shared.yml
+++ b/.github/workflows/copy-compat-to-docs-shared.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - "master"
     paths:
-      - "source/includes/mongodb-compatibility-table-java.rst"
-      - "source/includes/language-compatibility-table-java.rst"
+      - "source/includes/mongodb-compatibility-table-kotlin.rst"
+      - "source/includes/language-compatibility-table-kotlin.rst"
   workflow_dispatch:
 
 jobs:
@@ -21,21 +21,21 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source_file: "source/includes/mongodb-compatibility-table-java.rst"
+          source_file: "source/includes/mongodb-compatibility-table-kotlin.rst"
           destination_repo: "10gen/docs-shared"
           destination_folder: "dbx"
           user_email: "docs-builder-bot@mongodb.com"
           user_name: "docs-builder-bot"
-          commit_message: "Auto-import from docs-java"
+          commit_message: "Auto-import from docs-kotlin"
 
       - name: Copy language-compat table
         uses: dmnemec/copy_file_to_another_repo_action@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source_file: "source/includes/language-compatibility-table-java.rst"
+          source_file: "source/includes/language-compatibility-table-kotlin.rst"
           destination_repo: "10gen/docs-shared"
           destination_folder: "dbx"
           user_email: "docs-builder-bot@mongodb.com"
           user_name: "docs-builder-bot"
-          commit_message: "Auto-import from docs-java"
+          commit_message: "Auto-import from docs-kotlin"

--- a/source/includes/mongodb-compatibility-table-kotlin.rst
+++ b/source/includes/mongodb-compatibility-table-kotlin.rst
@@ -5,7 +5,6 @@
 
    * - Kotlin Driver Version
      - MongoDB 7.0
-     - MongoDB 6.1
      - MongoDB 6.0
      - MongoDB 5.0
      - MongoDB 4.4
@@ -16,7 +15,7 @@
      - MongoDB 3.2
      - MongoDB 3.0
      - MongoDB 2.6
-   
+
    * - 4.10
      - ✓
      - ✓
@@ -25,8 +24,8 @@
      - ✓
      - ✓
      - ✓
-     - ✓
      -
      -
      -
      -
+


### PR DESCRIPTION
# Pull Request Info

Removes rapid release version v6.1

Hope to also test the docs-shared copy GH action fixes.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - None
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/kotlin/092223-compatibility-copy/compatibility/#compatibility-table-legend

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
