### PR TITLE
DOCSP-36306: fix openssl tool link

### DIFF
--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -30,7 +30,7 @@ or `MongoClientSettings <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoCl
 .. note:: Debugging TLS/SSL
 
    If you experience trouble setting up your TLS/SSL connection, you can
-   use the ``-Djavax.net.debug=all`` system property to view additional
+   use the ``-Djavax.net.debug=all`` system property to view more
    log statements. See `the Oracle guide to debugging TLS/SSL connections
    <https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/ReadDebug.html>`__
    for more information.
@@ -89,7 +89,7 @@ Configure Certificates
 
 Kotlin applications that initiate TLS/SSL requests require access to
 cryptographic certificates that prove identity for the application
-itself as well as other applications with which the application
+itself and other applications with which the application
 interacts. You can configure access to these certificates in your application with
 the following mechanisms:
 
@@ -124,7 +124,7 @@ application is genuine and secure from tampering by third parties.
 If your MongoDB instance uses a certificate that is signed by an
 authority that is not present in the JRE's default certificate store,
 your application must configure two system properties to initiate
-SSL/TLS requests. These properties ensure that your application is able to
+SSL/TLS requests. These properties ensure that your application can
 validate the TLS/SSL certificate presented by a connected MongoDB instance.
 
 - ``javax.net.ssl.trustStore``: the path to a trust store containing the
@@ -148,8 +148,8 @@ Configure the JVM Key Store
 .. note::
 
    By default, MongoDB instances do not perform client certificate
-   validation. You only need to configure the key store if you explicitly
-   configured your MongoDB instance to validate client certificates.
+   validation. You must configure the key store if you configured your MongoDB
+   instance to validate client certificates.
 
 The JVM key store saves certificates that securely identify your Kotlin
 application to other applications. Using these certificates, other
@@ -168,11 +168,11 @@ the MongoDB server:
 
 You can create a key store with the `keytool
 <https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html>`__
-or `openssl <https://www.openssl.org/docs/apps/openssl.html>`__ command
-line tools.
+or `openssl <https://www.openssl.org/docs/manmaster/man1/openssl.html>`__
+command line tool.
 
 For more information on configuring a Kotlin application to use TLS/SSL,
-please refer to the `JSSE Reference Guide
+please seethe `JSSE Reference Guide
 <https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html>`__.
 
 .. _tls-disable-hostname-verification:
@@ -195,7 +195,7 @@ Disable Hostname Verification
 
 By default, the driver ensures that the hostname included in the server's
 TLS/SSL certificates matches the hostnames provided when constructing
-a ``MongoClient``. If you need to disable hostname verification for your
+a ``MongoClient``. To disable hostname verification for your
 application, you can explicitly disable this by setting the
 ``invalidHostNameAllowed`` property of the builder to ``true`` in the
 ``applytoSslSettings()`` builder lambda:
@@ -207,7 +207,7 @@ application, you can explicitly disable this by setting the
 
    Disabling hostname verification can make your configuration
    `insecure <https://tlseminar.github.io/docs/mostdangerous.pdf>`__.
-   You should only disable hostname verification for testing purposes or
+   Disable hostname verification only for testing purposes or
    when there is no other alternative.
 
 .. _tls-restrict-tls-1.2:
@@ -220,17 +220,17 @@ To restrict your application to use only the TLS 1.2 protocol, set the
 
 .. note::
 
-   Java Runtime Environments (JREs) prior to Java 8 only enabled
+   Java Runtime Environments (JREs) before Java 8 only enabled
    the TLS 1.2 protocol in update releases. If your JRE has not enabled
-   the TLS 1.2 protocol, you may need to upgrade to a later release to
-   connect using TLS 1.2.
+   the TLS 1.2 protocol, upgrade to a later release to connect by using
+   TLS 1.2.
 
 .. _tls-custom-sslContext:
 
 Customize TLS/SSL Configuration through the Java SE SSLContext
 --------------------------------------------------------------
 
-If your TLS/SSL configuration requires additional customization, you can
+If your TLS/SSL configuration requires customization, you can
 set the ``sslContext`` property of your ``MongoClient`` by
 passing an `SSLContext
 <https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html>`__
@@ -274,7 +274,7 @@ Online Certificate Status Protocol (OCSP)
 
 OCSP is a standard used to check whether X.509 certificates have been
 revoked. A certificate authority can add an X.509 certificate to the
-Certificate Revocation List (CRL) prior to the expiry time to invalidate
+Certificate Revocation List (CRL) before the expiry time to invalidate
 the certificate. When a client sends an X.509 certificate during the TLS
 handshake, the CA's revocation server checks the CRL and returns a status
 of "good", "revoked", or "unknown".
@@ -348,7 +348,7 @@ properties:
        |
        | If unset or set to ``false``, the connection can proceed regardless of the presence or status of the certificate revocation response.
 
-For additional information about OCSP, check out the following resources:
+For more information about OCSP, check out the following resources:
 
 - Oracle JDK 8 Documentation on `how to enable OCSP for an application <https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/ocsp.html>`__
 - :rfc:`Official IETF specification for OCSP (RFC 6960) <6960>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kotlin/blob/master/REVIEWING.md)

Same fixes from https://github.com/mongodb/docs-java/pull/523

JIRA - <https://jira.mongodb.org/browse/DOCSP-36306>
Staging: https://preview-mongodbcchomongodb.gatsbyjs.io/kotlin/DOCSP-36306-openssl-tool-link-fixes-2/fundamentals/connection/tls/#configure-the-jvm-key-store

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
