### PR TITLE
[Backport v5.1] DOCSP-44902 Shorten TOC

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -8,23 +8,23 @@ Fundamentals
    :titlesonly:
    :maxdepth: 1
 
-   /fundamentals/connection
-   /fundamentals/auth
-   /fundamentals/enterprise-auth
-   /fundamentals/stable-api
-   /fundamentals/databases-collections
-   /fundamentals/data-formats
-   /fundamentals/crud
-   /fundamentals/builders
-   /fundamentals/aggregation
-   /fundamentals/aggregation-expression-operations
-   /fundamentals/indexes
-   /fundamentals/transactions
-   /fundamentals/collations
-   /fundamentals/logging
-   /fundamentals/monitoring
-   /fundamentals/time-series
-   /fundamentals/encrypt-fields
+   Connection Guide </fundamentals/connection>
+   Authentication </fundamentals/auth>
+   Enterprise Authentication </fundamentals/enterprise-auth>
+   Stable API </fundamentals/stable-api>
+   Databases & Collections </fundamentals/databases-collections>
+   Data Formats </fundamentals/data-formats>
+   CRUD Operations /fundamentals/crud
+   Builders </fundamentals/builders>
+   Aggregation </fundamentals/aggregation>
+   Aggregation Expressions </fundamentals/aggregation-expression-operations>
+   Indexes </fundamentals/indexes>
+   Transactions </fundamentals/transactions>
+   Collations </fundamentals/collations>
+   Logging </fundamentals/logging>
+   Monitoring </fundamentals/monitoring>
+   Time Series Collections </fundamentals/time-series>
+   In-Use Encryption </fundamentals/encrypt-fields>
 
 .. TODO : add back in after MVP
    .. /fundamentals/gridfs

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -6,12 +6,12 @@ Builders
 
 .. toctree::
 
-   /fundamentals/builders/aggregates
-   /fundamentals/builders/filters
-   /fundamentals/builders/indexes
-   /fundamentals/builders/projections
-   /fundamentals/builders/sort
-   /fundamentals/builders/updates
+   Aggregation </fundamentals/builders/aggregates>
+   Filters </fundamentals/builders/filters>
+   Indexes </fundamentals/builders/indexes>
+   Projection </fundamentals/builders/projections>
+   Sort </fundamentals/builders/sort>
+   Update </fundamentals/builders/updates>
 
 .. contents:: On this page
    :local:

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -6,12 +6,12 @@ Connection Guide
 
 .. toctree::
 
-   /fundamentals/connection/connect
-   /fundamentals/connection/connection-options
-   /fundamentals/connection/mongoclientsettings
-   /fundamentals/connection/network-compression
-   /fundamentals/connection/tls
-   /fundamentals/connection/socks5
+   Connect to MongoDB </fundamentals/connection/connect>
+   Connection Options </fundamentals/connection/connection-options>
+   MongoClient Settings </fundamentals/connection/mongoclientsettings>
+   Network Compression </fundamentals/connection/network-compression>
+   TLS/SSL </fundamentals/connection/tls>
+   SOCKS5 Proxy Connection </fundamentals/connection/socks5>
 
 .. contents:: On this page
    :local:

--- a/source/fundamentals/crud.txt
+++ b/source/fundamentals/crud.txt
@@ -7,10 +7,10 @@ CRUD Operations
 .. toctree::
    :caption: CRUD Operations
 
-   /fundamentals/crud/read-operations
-   /fundamentals/crud/write-operations
-   /fundamentals/crud/query-document
-   /fundamentals/crud/compound-operations
+   Read </fundamentals/crud/read-operations>
+   Write </fundamentals/crud/write-operations>
+   Query </fundamentals/crud/query-document>
+   Compound Operations </fundamentals/crud/compound-operations>
 
 CRUD (Create, Read, Update, Delete) operations enable you to work with
 data stored in MongoDB.

--- a/source/fundamentals/data-formats.txt
+++ b/source/fundamentals/data-formats.txt
@@ -2,19 +2,19 @@
 Data Formats
 ============
 
+.. toctree::
+   :caption: Data Formats
+
+   Data Classes </fundamentals/data-formats/document-data-format-data-class>
+   BSON </fundamentals/data-formats/document-data-format-bson>
+   Extended JSON </fundamentals/data-formats/document-data-format-extended-json>
+   Documents </fundamentals/data-formats/documents>
+   Kotlin Serialization </fundamentals/data-formats/serialization>
+   Codecs </fundamentals/data-formats/codecs>
+
 - :doc:`/fundamentals/data-formats/document-data-format-data-class`
 - :doc:`/fundamentals/data-formats/document-data-format-bson`
 - :doc:`/fundamentals/data-formats/document-data-format-extended-json`
 - :doc:`/fundamentals/data-formats/documents`
 - :doc:`/fundamentals/data-formats/serialization`
 - :doc:`/fundamentals/data-formats/codecs`
-
-.. toctree::
-   :caption: Data Formats
-
-   /fundamentals/data-formats/document-data-format-data-class
-   /fundamentals/data-formats/document-data-format-bson
-   /fundamentals/data-formats/document-data-format-extended-json
-   /fundamentals/data-formats/documents
-   /fundamentals/data-formats/serialization
-   /fundamentals/data-formats/codecs

--- a/source/index.txt
+++ b/source/index.txt
@@ -7,17 +7,17 @@ MongoDB Kotlin Driver
    :maxdepth: 1
 
    Quick Start </quick-start>
-   /quick-reference
-   /whats-new
-   /usage-examples
-   /fundamentals
-   /api-documentation
-   /faq
-   /connection-troubleshooting
-   /issues-and-help
-   /compatibility
-   /migrate-kmongo
-   /validate-signatures
+   Quick Reference </quick-reference>
+   What's New </whats-new>
+   Usage Examples </usage-examples>
+   Fundamentals </fundamentals>
+   API Documentation </api-documentation>
+   FAQ </faq>
+   Connection Troubleshooting </connection-troubleshooting>
+   Issues & Help </issues-and-help>
+   Compatibility </compatibility>
+   Migrate from KMongo </migrate-kmongo>
+   Validate Driver Signatures </validate-signatures>
    View the Source <https://github.com/mongodb/mongo-java-driver>
 
 Introduction

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -10,16 +10,15 @@ Usage Examples
 
 .. toctree::
 
-   /usage-examples/find-operations
-   /usage-examples/insert-operations
-   /usage-examples/update-operations
-   /usage-examples/delete-operations
-   /usage-examples/bulkWrite
-   /usage-examples/watch
-   /usage-examples/count
-   /usage-examples/distinct
-   /usage-examples/command
-
+   Find </usage-examples/find-operations>
+   Insert </usage-examples/insert-operations>
+   Update & Replaces </usage-examples/update-operations>
+   Delete </usage-examples/delete-operations>
+   Bulk Operations </usage-examples/bulkWrite>
+   Watch for Changes </usage-examples/watch>
+   Count Documents </usage-examples/count>
+   Distinct Field Values </usage-examples/distinct>
+   Run a Command </usage-examples/command>
 
 Overview
 --------

--- a/source/usage-examples/delete-operations.txt
+++ b/source/usage-examples/delete-operations.txt
@@ -2,12 +2,12 @@
 Delete Operations
 =================
 
-- :doc:`Delete a Document </usage-examples/deleteOne>`
-- :doc:`Delete Multiple Documents </usage-examples/deleteMany>`
-
 .. toctree::
    :caption: Examples
 
-   /usage-examples/deleteOne
-   /usage-examples/deleteMany
+   Delete One </usage-examples/deleteOne>
+   Delete Many </usage-examples/deleteMany>
+
+- :doc:`Delete a Document </usage-examples/deleteOne>`
+- :doc:`Delete Multiple Documents </usage-examples/deleteMany>`
   

--- a/source/usage-examples/find-operations.txt
+++ b/source/usage-examples/find-operations.txt
@@ -2,11 +2,11 @@
 Find Operations
 ===============
 
-- :doc:`Find a Document </usage-examples/findOne>`
-- :doc:`Find Multiple Documents </usage-examples/find>`
-
 .. toctree::
    :caption: Examples
 
-   /usage-examples/findOne
-   /usage-examples/find
+   Find One </usage-examples/findOne>
+   Find Many </usage-examples/find>
+
+- :doc:`Find a Document </usage-examples/findOne>`
+- :doc:`Find Multiple Documents </usage-examples/find>`

--- a/source/usage-examples/insert-operations.txt
+++ b/source/usage-examples/insert-operations.txt
@@ -2,11 +2,11 @@
 Insert Operations
 =================
 
-- :doc:`Insert a Document </usage-examples/insertOne>`
-- :doc:`Insert Multiple Documents </usage-examples/insertMany>`
-
 .. toctree::
    :caption: Examples
 
-   /usage-examples/insertOne
-   /usage-examples/insertMany
+   Insert One </usage-examples/insertOne>
+   Insert Many </usage-examples/insertMany>
+
+- :doc:`Insert a Document </usage-examples/insertOne>`
+- :doc:`Insert Multiple Documents </usage-examples/insertMany>`

--- a/source/usage-examples/update-operations.txt
+++ b/source/usage-examples/update-operations.txt
@@ -2,13 +2,13 @@
 Update & Replace Operations
 ===========================
 
-- :doc:`Update a Document </usage-examples/updateOne>`
-- :doc:`Update Multiple Documents </usage-examples/updateMany>`
-- :doc:`Replace a Document </usage-examples/replaceOne>`
-
 .. toctree::
    :caption: Examples
 
-   /usage-examples/updateOne
-   /usage-examples/updateMany
-   /usage-examples/replaceOne
+   Update One </usage-examples/updateOne>
+   Update Many </usage-examples/updateMany>
+   Replace One </usage-examples/replaceOne>
+
+- :doc:`Update a Document </usage-examples/updateOne>`
+- :doc:`Update Multiple Documents </usage-examples/updateMany>`
+- :doc:`Replace a Document </usage-examples/replaceOne>`


### PR DESCRIPTION
* DOCSP-44902 TOC Relabel

* DOCSP-44902 TOC Relabel

* Mike's suggestions

* 'one/many' operation changes

(cherry picked from commit 1144bde00f5ce107638a6d2664abce2ea62aad3b)

Co-authored-by: lindseymoore <71525840+lindseymoore@users.noreply.github.com>
(cherry picked from commit bc41eefcc7e17f719a9a4a50344cdab7d8ad16e1)

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kotlin/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
