### PR TITLE
[v5.4] Docsp-49013  (#226)

### DIFF
--- a/source/fundamentals/builders/builders-data-classes.txt
+++ b/source/fundamentals/builders/builders-data-classes.txt
@@ -49,6 +49,12 @@ To implement this functionality, you must add the
 ``mongodb-driver-kotlin-extensions`` dependency to your dependencies
 list.
 
+.. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+   .. replacement:: installation-guide
+
+      :ref:`Add the Driver Bill of Materials <kotlin-get-started-install-bom>` step of the Quick Start guide.
+
 Select from the following tabs to see how to add the extension
 dependency to your project by using the :guilabel:`Gradle` and
 :guilabel:`Maven` package managers:
@@ -64,7 +70,7 @@ dependency to your project by using the :guilabel:`Gradle` and
       .. code-block:: kotlin
          :caption: build.gradle.kts
  
-         implementation("org.mongodb:mongodb-driver-kotlin-extensions:{+full-version+}")
+         implementation("org.mongodb:mongodb-driver-kotlin-extensions")
 
    .. tab::
       :tabid: Maven
@@ -78,7 +84,6 @@ dependency to your project by using the :guilabel:`Gradle` and
          <dependency>
              <groupId>org.mongodb</groupId>
              <artifactId>mongodb-driver-kotlin-extensions</artifactId>
-             <version>{+full-version+}</version>
          </dependency>
 
 After you install the extensions dependency, you can use the extension

--- a/source/fundamentals/data-formats/document-data-format-bson.txt
+++ b/source/fundamentals/data-formats/document-data-format-bson.txt
@@ -60,6 +60,12 @@ MongoDB Kotlin driver as a dependency to your project, see the
 :ref:`driver installation <add-mongodb-dependency>` section of our Quick Start
 guide.
 
+.. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+   .. replacement:: installation-guide
+
+      :ref:`Add the Driver Bill of Materials <kotlin-get-started-install-bom>` step of the Quick Start guide.
+
 We recommend that you use the `Maven <https://maven.apache.org/>`__ or
 `Gradle <https://gradle.org/>`__ build automation tool to manage your project's
 dependencies. Select from the following tabs to see the dependency declaration

--- a/source/fundamentals/data-formats/serialization.txt
+++ b/source/fundamentals/data-formats/serialization.txt
@@ -60,6 +60,12 @@ Add {+language+} Serialization to Your Project
 Support for serialization in the {+driver-short+} depends on the official `Kotlin
 serialization library <https://github.com/Kotlin/kotlinx.serialization>`__.
 
+.. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+   .. replacement:: installation-guide
+
+      :ref:`Add the Driver Bill of Materials <kotlin-get-started-install-bom>` step of the Quick Start guide.
+
 Select from the following tabs to see how to add the serialization
 dependencies to your project by using the :guilabel:`Gradle` and
 :guilabel:`Maven` package managers:
@@ -76,7 +82,7 @@ dependencies to your project by using the :guilabel:`Gradle` and
         :caption: build.gradle.kts
 
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:{+serializationVersion+}")
-        implementation("org.mongodb:bson-kotlinx:{+full-version+}")
+        implementation("org.mongodb:bson-kotlinx")
 
    .. tab::
       :tabid: Maven
@@ -95,7 +101,6 @@ dependencies to your project by using the :guilabel:`Gradle` and
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>bson-kotlinx</artifactId>
-            <version>{+full-version+}</version>
         </dependency>
 
 .. _kotlin-data-class-annotation:
@@ -191,7 +196,7 @@ add the dependency to your project by using the :guilabel:`Gradle` and
       .. code-block:: kotlin
         :caption: build.gradle.kts
 
-        implementation("org.mongodb:bson-kotlinx:{+full-version+}")
+        implementation("org.mongodb:bson-kotlinx")
 
    .. tab::
       :tabid: Maven
@@ -205,7 +210,6 @@ add the dependency to your project by using the :guilabel:`Gradle` and
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>bson-kotlinx</artifactId>
-            <version>{+full-version+}</version>
         </dependency>
 
 .. note:: bson-kotlin Dependency

--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -4,25 +4,32 @@
 
    .. replacement:: driver-specific-content
 
-      .. important:: Compatible Encryption Library Version
+      Compatible Encryption Library Version
+      -------------------------------------
 
-         The {+driver-short+} uses the `mongodb-crypt
-         <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
-         encryption library for in-use encryption. This driver version
-         is compatible with ``mongodb-crypt`` v{+mongocrypt-version+}.
+      The {+driver-short+} uses the `mongodb-crypt
+      <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
+      encryption library for in-use encryption. This driver version
+      is compatible with ``mongodb-crypt`` v{+mongocrypt-version+}.
 
-         Select from the following :guilabel:`Maven` and
-         :guilabel:`Gradle` tabs to see how to add the ``mongodb-crypt``
-         dependency to your project by using the specified manager:
-         
-         .. tabs::
-         
-            .. tab:: Maven
-               :tabid: maven-dependency
-         
-               .. include:: /includes/fundamentals/code-snippets/crypt-maven-versioned.rst
-         
-            .. tab:: Gradle
-               :tabid: gradle-dependency
-         
-               .. include:: /includes/fundamentals/code-snippets/crypt-gradle-versioned.rst
+      .. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+         .. replacement:: installation-guide
+
+            :ref:`Add the Driver Bill of Materials <kotlin-get-started-install-bom>` step of the Quick Start guide.
+
+      Select from the following :guilabel:`Maven` and
+      :guilabel:`Gradle` tabs to see how to add the ``mongodb-crypt``
+      dependency to your project by using the specified manager:
+      
+      .. tabs::
+      
+         .. tab:: Maven
+            :tabid: maven-dependency
+      
+            .. include:: /includes/fundamentals/code-snippets/crypt-maven-versioned.rst
+      
+         .. tab:: Gradle
+            :tabid: gradle-dependency
+      
+            .. include:: /includes/fundamentals/code-snippets/crypt-gradle-versioned.rst

--- a/source/includes/fundamentals/code-snippets/bson-gradle-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/bson-gradle-versioned.rst
@@ -1,6 +1,6 @@
 .. code-block:: kotlin
 
    dependencies {
-      implementation("org.mongodb:bson:{+full-version+}")
+      implementation("org.mongodb:bson")
    }
 

--- a/source/includes/fundamentals/code-snippets/bson-maven-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/bson-maven-versioned.rst
@@ -4,7 +4,6 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>bson</artifactId>
-           <version>{+full-version+}</version>
        </dependency>
    </dependencies>
 

--- a/source/includes/fundamentals/code-snippets/crypt-gradle-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/crypt-gradle-versioned.rst
@@ -1,5 +1,5 @@
 .. code-block:: groovy
 
    dependencies {
-      implementation("org.mongodb:mongodb-crypt:{+mongocrypt-version+}")
+      implementation("org.mongodb:mongodb-crypt")
    }

--- a/source/includes/fundamentals/code-snippets/crypt-maven-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/crypt-maven-versioned.rst
@@ -4,6 +4,5 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>mongodb-crypt</artifactId>
-           <version>{+mongocrypt-version+}</version>
        </dependency>
    </dependencies>

--- a/source/includes/serialization-libs-gradle-versioned.rst
+++ b/source/includes/serialization-libs-gradle-versioned.rst
@@ -2,7 +2,7 @@
    :caption: build.gradle.kts
    :copyable: true
 
-   implementation("org.mongodb:bson-kotlinx:{+full-version+}")
+   implementation("org.mongodb:bson-kotlinx")
    // OR
-   implementation("org.mongodb:bson-kotlin:{+full-version+}")
+   implementation("org.mongodb:bson-kotlin")
    

--- a/source/includes/serialization-libs-maven-versioned.rst
+++ b/source/includes/serialization-libs-maven-versioned.rst
@@ -5,12 +5,10 @@
    <dependency>
        <groupId>org.mongodb</groupId>
        <artifactId>bson-kotlinx</artifactId>
-       <version>{+full-version+}</version>
    </dependency>
    <!--OR-->
    <dependency>
        <groupId>org.mongodb</groupId>
        <artifactId>bson-kotlin</artifactId>
-       <version>{+full-version+}</version>
    </dependency>
   


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.4`:
 - [Docsp-49013  (#226)](https://github.com/mongodb/docs-kotlin/pull/226)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)