### PR TITLE
DOCSP-52044: Fix duplicate insert titles

### DIFF
--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -1,8 +1,8 @@
 .. _kotlin-fundamentals-insert:
 
-=================
-Insert Operations
-=================
+================
+Insert Documents
+================
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-kotlin/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-52044

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-237--docs-kotlin.netlify.app/fundamentals/crud/write-operations/insert>fundamentals/crud/write-operations/insert</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
