### PR TITLE
[v5.4] DOCSP-48715-username-pw (#238)

### DIFF
--- a/examples/src/test/kotlin/MongoClientSettingsTest.kt
+++ b/examples/src/test/kotlin/MongoClientSettingsTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.Ignore
 // }
 
 /* NOTE: These tests are not run by default because they require a MongoDB deployment
-with a username and password. To run these tests locally, you need to set up your .env
+with a database username and database password. To run these tests locally, you need to set up your .env
 and replace the @Ignore annotation with @Test on the tests you want to run.
  */
 class MongoClientSettingsTest {

--- a/examples/src/test/kotlin/NetworkCompressionTest.kt
+++ b/examples/src/test/kotlin/NetworkCompressionTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertEquals
 // :replace-start: {
 //    "terms": {
 //       "CONNECTION_URI_PLACEHOLDER": "\"<connection string>\"",
-//       "${uri}&": "mongodb+srv://<user>:<password>@<cluster-url>/?"
+//       "${uri}&": "mongodb+srv://<db_username>:<db_password>@<cluster-url>/?"
 //    }
 // }
 

--- a/examples/src/test/kotlin/SocksTest.kt
+++ b/examples/src/test/kotlin/SocksTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.Ignore
 // :replace-start: {
 //    "terms": {
 //       "CONNECTION_URI_PLACEHOLDER": "\"<connection string>\"",
-//       "${uri}&": "mongodb+srv://<user>:<password>@<cluster-url>/?"
+//       "${uri}&": "mongodb+srv://<db_username>:<db_password>@<cluster-url>/?"
 //    }
 // }
 

--- a/examples/src/test/kotlin/TlsTest.kt
+++ b/examples/src/test/kotlin/TlsTest.kt
@@ -32,7 +32,7 @@ internal class TlsTest {
     @Disabled("Disabled because host does not exist")
     fun tlsConnectionStringTest() = runBlocking {
         // :snippet-start: tls-connection-string
-        val mongoClient = MongoClient.create("mongodb+srv://<user>:<password>@<cluster-url>?tls=true")
+        val mongoClient = MongoClient.create("mongodb+srv://<db_username>:<db_password>@<cluster-url>?tls=true")
         // :snippet-end:
         mongoClient.close()
     }

--- a/source/connection-troubleshooting.txt
+++ b/source/connection-troubleshooting.txt
@@ -92,12 +92,12 @@ issues when attempting to connect to MongoDB.
    For more information about using connection strings with the {+driver-short+},
    see :ref:`Connection URI <connection-uri>` in the Connection Guide.
 
-If your connection string contains a username and password, ensure that they
+If your connection string contains a database username and database password, ensure that they
 are in the correct format.
 
 .. note::
 
-   If the username or password includes any of the following characters, they
+   If the database username or database password includes any of the following characters, they
    must be `percent encoded <https://tools.ietf.org/html/rfc3986#section-2.1>`__:
 
    .. code-block:: none
@@ -119,8 +119,8 @@ connection if one of the hosts is unreachable.
 Verify User Is in Authentication Database
 -----------------------------------------
 
-To successfully authenticate a connection by using a username and password,
-the username must be defined in the authentication database. The default
+To successfully authenticate a connection by using a database username and database password,
+the database username must be defined in the authentication database. The default
 authentication database is the ``admin`` database. To use a different database
 for authentication, specify the ``authSource`` in the connection string. The
 following example instructs the driver to use ``users`` as the authentication

--- a/source/examples/generated/NetworkCompressionTest.snippet.connection-string-compression-example.kt
+++ b/source/examples/generated/NetworkCompressionTest.snippet.connection-string-compression-example.kt
@@ -1,5 +1,5 @@
 // Replace the placeholders with values from your MongoDB deployment's connection string
-val connectionString = ConnectionString("mongodb+srv://<user>:<password>@<cluster-url>/?compressors=snappy,zlib,zstd")
+val connectionString = ConnectionString("mongodb+srv://<db_username>:<db_password>@<cluster-url>/?compressors=snappy,zlib,zstd")
 
 // Create a new client with your settings
 val mongoClient = MongoClient.create(connectionString)

--- a/source/examples/generated/SocksTest.snippet.socks-connection-string.kt
+++ b/source/examples/generated/SocksTest.snippet.socks-connection-string.kt
@@ -1,5 +1,5 @@
 val connectionString = ConnectionString(
-    "mongodb+srv://<user>:<password>@<cluster-url>/?" +
+    "mongodb+srv://<db_username>:<db_password>@<cluster-url>/?" +
         "proxyHost=<proxyHost>" +
         "&proxyPort=<proxyPort>" +
         "&proxyUsername=<proxyUsername>" +

--- a/source/examples/generated/TlsTest.snippet.tls-connection-string.kt
+++ b/source/examples/generated/TlsTest.snippet.tls-connection-string.kt
@@ -1,1 +1,1 @@
-val mongoClient = MongoClient.create("mongodb+srv://<user>:<password>@<cluster-url>?tls=true")
+val mongoClient = MongoClient.create("mongodb+srv://<db_username>:<db_password>@<cluster-url>?tls=true")

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -66,7 +66,7 @@ to learn how to allow connections to your instance of Atlas and to find the
 :manual:`connection string </reference/connection-string/>` you use to replace the
 ``uri`` variable in usage examples. If your instance uses
 :manual:`SCRAM authentication </core/security-scram/>`, you can replace
-``<user>`` with your username, ``<password>`` with your password, and
+``<db_username>`` with your database username, ``<db_password>`` with your database password, and
 ``<cluster-url>`` with the IP address or URL of your instance.
 
 For more information about connecting to your MongoDB instance, see our


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.4`:
 - [DOCSP-48715-username-pw (#238)](https://github.com/mongodb/docs-kotlin/pull/238)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)